### PR TITLE
Remove selection of "generic" and "isS4" columns as they did not exist before R 3.2

### DIFF
--- a/R/docs.R
+++ b/R/docs.R
@@ -20,7 +20,7 @@ methods_find <- function(x, visible = TRUE) {
   info$package <- vapply(pieces, last, n = 2, FUN.VALUE = character(1))
   info$topic <- vapply(pieces, last, character(1))
 
-  info[c("method", "generic", "class", "package", "topic", "visible", "source", "isS4")]
+  info[c("method", "class", "package", "topic", "visible", "source")]
 }
 
 methods_rd <- function(x) {


### PR DESCRIPTION
It does not break anything to remove these (they were returned but never used), and should fix the build issue on R 3.1

Addition of these columns in 3.2 is here:
https://github.com/wch/r-source/commit/b7a1ced5963a271a2872d03456e5b6e67e187f0a#diff-b608619671dcbd95cb6acb8e838cad30R74

Update) Looks like it worked!