### PR TITLE
Remove exclusion of non-visible methods

### DIFF
--- a/R/docs.R
+++ b/R/docs.R
@@ -1,12 +1,8 @@
 # Modified from sloop::methods_generic
-methods_find <- function(x, visible = TRUE) {
+methods_find <- function(x) {
   info <- attr(utils::methods(x), "info")
   info$method <- rownames(info)
   rownames(info) <- NULL
-
-  if (visible) {
-    info <- info[info$visible, , drop = FALSE]
-  }
 
   # Simply class and source
   generic_esc <- gsub("\\.", "\\\\.", x)


### PR DESCRIPTION
Closes #14.

I simply removed the `visible` argument altogether, since I don't think we need it anymore.

S3 methods that do not have documentation (aka no "topic") are already automatically excluded.
https://github.com/r-lib/generics/blob/master/R/docs.R#L28