### PR TITLE
Feature/speed up help path lookup

### DIFF
--- a/R/docs.R
+++ b/R/docs.R
@@ -11,7 +11,7 @@ methods_find <- function(x) {
   info$source <- gsub(paste0(" for ", generic_esc), "", info$from)
 
   # Find package
-  info$package <- lookup_package(info$generic, info$class)
+  info$package <- lookup_package(x, info$class)
 
   # Find help topic
   path <- help_path(info$method, info$package)

--- a/R/docs.R
+++ b/R/docs.R
@@ -59,7 +59,7 @@ last <- function(x, n = 0) {
 help_path <- function(generic, class) {
 
   lookup_package <- function(generic, class) {
-    packageName(environment(getS3method(generic, class)))
+    utils::packageName(environment(utils::getS3method(generic, class)))
   }
 
   generic_class <- paste(generic, class, sep = ".")

--- a/R/docs.R
+++ b/R/docs.R
@@ -11,7 +11,7 @@ methods_find <- function(x) {
   info$source <- gsub(paste0(" for ", generic_esc), "", info$from)
 
   # Find help topic
-  path <- help_path(info$method)
+  path <- help_path(info$generic, info$class)
   pieces <- strsplit(path, "/")
   info$package <- vapply(pieces, last, n = 2, FUN.VALUE = character(1))
   info$topic <- vapply(pieces, last, character(1))
@@ -56,10 +56,23 @@ last <- function(x, n = 0) {
   }
 }
 
-help_path <- function(x) {
-  help <- lapply(x, utils::help)
+help_path <- function(generic, class) {
+
+  lookup_package <- function(generic, class) {
+    packageName(environment(getS3method(generic, class)))
+  }
+
+  generic_class <- paste(generic, class, sep = ".")
+
+  pkg <- map2(generic, class, lookup_package)
+  help <- map2(generic_class, pkg, utils::help)
+
   vapply(help,
     function(x) if (length(x) == 0) NA_character_ else as.character(x),
     FUN.VALUE = character(1)
   )
+}
+
+map2 <- function(.x, .y, .f, ...) {
+  mapply(.f, .x, .y, MoreArgs = list(...), SIMPLIFY = FALSE)
 }

--- a/R/docs.R
+++ b/R/docs.R
@@ -1,12 +1,8 @@
 # Modified from sloop::methods_generic
-methods_find <- function(x, visible = TRUE) {
+methods_find <- function(x) {
   info <- attr(utils::methods(x), "info")
   info$method <- rownames(info)
   rownames(info) <- NULL
-
-  if (visible) {
-    info <- info[info$visible, , drop = FALSE]
-  }
 
   # Simply class and source
   generic_esc <- gsub("\\.", "\\\\.", x)

--- a/R/docs.R
+++ b/R/docs.R
@@ -27,7 +27,7 @@ methods_rd <- function(x) {
     return("No methods found in currently loaded packages.")
   }
 
-  topics <- split(methods, list(methods$topic, methods$package))
+  topics <- split(methods, paste(methods$topic, methods$package, sep = "."))
   names(topics) <- NULL
 
   bullets <- vapply(topics, function(x) {


### PR DESCRIPTION
I noticed that for functions with a large number of methods, like `tidy()`, the dynamic docs can be a bit slow (taking about 2 seconds to load when `broom` is loaded as well). This was due to repeated calls to `readRDS()` in `utils::help()` as it looped over all of the packages in the search path to find the help doc.

`utils::help()` has a `package` argument that we can use to speed it up by telling it exactly where to look for the method's help docs. This PR utilizes that, and finds the package name by using `packageName(environment(getS3method(generic, class)))`.

I'm not sure if this needs to be made more robust (support for S4?), but with `tidy()` it works great and doc loading times are much faster (down to <100 ms).

Note that this is branched from PR #14. 