### PR TITLE
Fix/ Support s4 and improve Rd doc output

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,3 +17,5 @@ Depends:
     R (>= 3.1)
 Suggests: 
     covr
+Imports: 
+    methods

--- a/R/docs.R
+++ b/R/docs.R
@@ -9,7 +9,7 @@ methods_find <- function(x) {
   info$method <- rownames(info)
   rownames(info) <- NULL
 
-  if(getRversion() <= R_system_version("3.1.3")) {
+  if(getRversion() < "3.2") {
     info$isS4 <- grepl("-method$", info$method)
   }
 

--- a/R/docs.R
+++ b/R/docs.R
@@ -1,8 +1,17 @@
 # Modified from sloop::methods_generic
 methods_find <- function(x) {
   info <- attr(utils::methods(x), "info")
+
+  if(nrow(info) == 0) {
+    return(data.frame())
+  }
+
   info$method <- rownames(info)
   rownames(info) <- NULL
+
+  if(getRversion() <= R_system_version("3.1.3")) {
+    info$isS4 <- grepl("-method$", info$method)
+  }
 
   # Simply class and source
   generic_esc <- gsub("\\.", "\\\\.", x)
@@ -11,7 +20,7 @@ methods_find <- function(x) {
   info$source <- gsub(paste0(" for ", generic_esc), "", info$from)
 
   # Find package
-  info$package <- lookup_package(x, info$class)
+  info$package <- lookup_package(x, info$class, info$isS4)
 
   # Find help topic
   path <- help_path(info$method, info$package)
@@ -29,21 +38,43 @@ methods_rd <- function(x) {
     return("No methods found in currently loaded packages.")
   }
 
-  topics <- split(methods, paste(methods$topic, methods$package, sep = "."))
-  names(topics) <- NULL
+  methods_by_package <- split(methods, methods$package)
 
-  bullets <- vapply(topics, function(x) {
-    link <- paste0("\\code{\\link[", x$package[[1]], "]{", x$topic[[1]], "}}")
-    classes <- paste0("\\code{", x$class, "}", collapse = ", ")
-    paste0("\\item ", link, ": ", classes)
-  }, character(1))
+  topics_by_package <- lapply(methods_by_package, function(x) {
+    split(x, paste(x$topic, x$package, sep = "."))
+  })
+
+  make_bullets <- function(topics) {
+    bullet_vec <- vapply(
+      X = topics,
+      FUN = function(x) {
+        link <- paste0("\\code{\\link[", x$package[[1]], "]{", x$topic[[1]], "}}")
+        classes <- paste0("\\code{", x$class, "}", collapse = ", ")
+        paste0("\\item ", link, ": ", classes)
+      },
+      FUN.VALUE = character(1),
+      USE.NAMES = FALSE
+    )
+
+    paste0(bullet_vec, collapse = "\n")
+  }
+
+  make_header <- function(pkg) {
+    paste0("\\code{", pkg, "}")
+  }
+
+  bullets <- lapply(topics_by_package, make_bullets)
+  headers <- lapply(names(topics_by_package), make_header)
 
   paste0(
-    c(
-      "See the following help topics for more details about individual methods:",
-      "\\itemize{",
-      bullets,
-      "}"
+    c("See the following help topics for more details about individual methods:\n",
+      paste(
+        headers,
+        "\\itemize{",
+        bullets,
+        "}",
+        sep = "\n"
+      )
     ),
     collapse = "\n"
   )
@@ -59,7 +90,8 @@ last <- function(x, n = 0) {
 }
 
 help_path <- function(x, package) {
-  help <- map2(x, package, utils::help)
+
+  help <- mapply(locate_help_doc, x, package, SIMPLIFY = FALSE)
 
   vapply(help,
     function(x) if (length(x) == 0) NA_character_ else as.character(x),
@@ -67,19 +99,44 @@ help_path <- function(x, package) {
   )
 }
 
-lookup_package <- function(generic, class) {
-  lookup_single_package <- function(generic, class) {
-    fn <- utils::getS3method(generic, class)
-    utils::packageName(environment(fn))
+locate_help_doc <- function(x, package) {
+  if(is.na(package)) {
+    utils::help(x)
+  } else {
+    utils::help(x, (package))
+  }
+}
+
+lookup_package <- function(generic, class, is_s4) {
+
+  lookup_single_package <- function(generic, class, is_s4) {
+
+    if(is_s4) {
+
+      class <- strsplit(class, ",")[[1]]
+      fn <- methods::getMethod(generic, class, optional = TRUE)
+
+    } else {
+
+      fn <- utils::getS3method(generic, class, optional = TRUE)
+
+    }
+
+    # Not found
+    if(is.null(fn)) {
+      return(NA_character_)
+    }
+
+    pkg <- utils::packageName(environment(fn))
+
+    # Function method found, but in a non-package environment
+    if(is.null(pkg)) {
+      return(NA_character_)
+    }
+
+    pkg
   }
 
-  map2_chr(generic, class, lookup_single_package)
-}
-
-map2 <- function(.x, .y, .f, ...) {
-  mapply(.f, .x, .y, MoreArgs = list(...), SIMPLIFY = FALSE)
-}
-
-map2_chr <- function(.x, .y, .f, ...) {
-  as.vector(map2(.x, .y, .f, ...), "character")
+  pkgs <- mapply(lookup_single_package, generic, class, is_s4, SIMPLIFY = FALSE)
+  as.vector(pkgs, "character")
 }


### PR DESCRIPTION
A few improvements to the last PR. When we added the speed improvements, we lost the ability to support S4 and ignore things like methods defined on an ad-hoc basis like in the global environment. This PR supports both of those now, using `methods::getMethod()` for S4.

It also improves on the Rd output, especially when there are multiple packages, by adding a header for the package that the method comes from. This is very useful for `recipes`, which loads `broom`, so you can tell which of the many `tidy` methods goes with which package.

Below is what you see when you do `?as.difftime` with `lubridate` loaded. (this is the only one where `generics` shows up because the default implementation of `as.difftime` has different args than the generic version so we added the default to the Rd).

![screen shot 2018-09-28 at 10 38 40 am](https://user-images.githubusercontent.com/19150088/46215182-b810d400-c30a-11e8-9eb3-01a4b8a05959.png)
