### PR TITLE
Dynamic docs) sets & coercion

### DIFF
--- a/R/coercion.R
+++ b/R/coercion.R
@@ -7,7 +7,15 @@
 #' default methods call the base versions.
 #'
 #' @section Methods:
+#'
+#' **`as.factor()`**
+#'
 #' \Sexpr[stage=render,results=Rd]{generics:::methods_rd("as.factor")}
+#'
+#' \cr
+#' **`as.ordered()`**
+#'
+#' \Sexpr[stage=render,results=Rd]{generics:::methods_rd("as.ordered")}
 #'
 #' @param x A vector of data.
 #' @param ... Other arguments passed on to methods.

--- a/R/coercion.R
+++ b/R/coercion.R
@@ -8,14 +8,14 @@
 #'
 #' @section Methods:
 #'
-#' **`as.factor()`**
+#' \subsection{`as.factor()`}{
+#'    \Sexpr[stage=render,results=Rd]{generics:::methods_rd("as.factor")}
+#' }
 #'
-#' \Sexpr[stage=render,results=Rd]{generics:::methods_rd("as.factor")}
+#' \subsection{`as.ordered()`}{
+#'    \Sexpr[stage=render,results=Rd]{generics:::methods_rd("as.ordered")}
+#' }
 #'
-#' \cr
-#' **`as.ordered()`**
-#'
-#' \Sexpr[stage=render,results=Rd]{generics:::methods_rd("as.ordered")}
 #'
 #' @param x A vector of data.
 #' @param ... Other arguments passed on to methods.

--- a/R/sets.R
+++ b/R/sets.R
@@ -10,29 +10,25 @@
 #'
 #' @section Methods:
 #'
-#' **`intersect()`**
+#' \subsection{`intersect()`}{
+#'     \Sexpr[stage=render,results=Rd]{generics:::methods_rd("intersect")}
+#' }
 #'
-#' \Sexpr[stage=render,results=Rd]{generics:::methods_rd("intersect")}
+#' \subsection{`union()`}{
+#'    \Sexpr[stage=render,results=Rd]{generics:::methods_rd("union")}
+#' }
 #'
-#' \cr
-#' **`union()`**
+#' \subsection{`setdiff()`}{
+#'    \Sexpr[stage=render,results=Rd]{generics:::methods_rd("setdiff")}
+#' }
 #'
-#' \Sexpr[stage=render,results=Rd]{generics:::methods_rd("union")}
+#' \subsection{`setequal()`}{
+#'    \Sexpr[stage=render,results=Rd]{generics:::methods_rd("setequal")}
+#' }
 #'
-#' \cr
-#' **`setdiff()`**
-#'
-#' \Sexpr[stage=render,results=Rd]{generics:::methods_rd("setdiff")}
-#'
-#' \cr
-#' **`setequal()`**
-#'
-#' \Sexpr[stage=render,results=Rd]{generics:::methods_rd("setequal")}
-#'
-#' \cr
-#' **`is.element()`**
-#'
-#' \Sexpr[stage=render,results=Rd]{generics:::methods_rd("is.element")}
+#' \subsection{`is.element()`}{
+#'    \Sexpr[stage=render,results=Rd]{generics:::methods_rd("is.element")}
+#' }
 #'
 #' @param x,y Vectors to combine.
 #' @param el,set Element and set to compare.

--- a/R/sets.R
+++ b/R/sets.R
@@ -9,7 +9,30 @@
 #' default methods call the base versions.
 #'
 #' @section Methods:
+#'
+#' **`intersect()`**
+#'
 #' \Sexpr[stage=render,results=Rd]{generics:::methods_rd("intersect")}
+#'
+#' \cr
+#' **`union()`**
+#'
+#' \Sexpr[stage=render,results=Rd]{generics:::methods_rd("union")}
+#'
+#' \cr
+#' **`setdiff()`**
+#'
+#' \Sexpr[stage=render,results=Rd]{generics:::methods_rd("setdiff")}
+#'
+#' \cr
+#' **`setequal()`**
+#'
+#' \Sexpr[stage=render,results=Rd]{generics:::methods_rd("setequal")}
+#'
+#' \cr
+#' **`is.element()`**
+#'
+#' \Sexpr[stage=render,results=Rd]{generics:::methods_rd("is.element")}
 #'
 #' @param x,y Vectors to combine.
 #' @param el,set Element and set to compare.

--- a/R/sets.R
+++ b/R/sets.R
@@ -64,7 +64,7 @@ setdiff <- function(x, y, ...) UseMethod("setdiff")
 setequal <- function(x, y, ...) UseMethod("setequal")
 #' @rdname setops
 #' @export
-is.element <- function(el, set, ...) UseMethod("setequal")
+is.element <- function(el, set, ...) UseMethod("is.element")
 
 #' @export
 intersect.default <- function(x, y, ...) base::intersect(x, y, ...)

--- a/man/coercion-factor.Rd
+++ b/man/coercion-factor.Rd
@@ -29,7 +29,15 @@ default methods call the base versions.
 }
 \section{Methods}{
 
+
+\strong{\code{as.factor()}}
+
 \Sexpr[stage=render,results=Rd]{generics:::methods_rd("as.factor")}
+
+\cr
+\strong{\code{as.ordered()}}
+
+\Sexpr[stage=render,results=Rd]{generics:::methods_rd("as.ordered")}
 }
 
 \examples{

--- a/man/coercion-factor.Rd
+++ b/man/coercion-factor.Rd
@@ -30,14 +30,13 @@ default methods call the base versions.
 \section{Methods}{
 
 
-\strong{\code{as.factor()}}
-
+\subsection{\code{as.factor()}}{
 \Sexpr[stage=render,results=Rd]{generics:::methods_rd("as.factor")}
+}
 
-\cr
-\strong{\code{as.ordered()}}
-
+\subsection{\code{as.ordered()}}{
 \Sexpr[stage=render,results=Rd]{generics:::methods_rd("as.ordered")}
+}
 }
 
 \examples{

--- a/man/generics-package.Rd
+++ b/man/generics-package.Rd
@@ -36,6 +36,12 @@ Useful links:
 \author{
 \strong{Maintainer}: Max Kuhn \email{max@rstudio.com}
 
+Authors:
+\itemize{
+  \item Hadley Wickham \email{hadley@rstudio.com}
+  \item Davis Vaughan \email{davis@rstudio.com}
+}
+
 Other contributors:
 \itemize{
   \item RStudio [copyright holder]

--- a/man/setops.Rd
+++ b/man/setops.Rd
@@ -45,29 +45,25 @@ default methods call the base versions.
 \section{Methods}{
 
 
-\strong{\code{intersect()}}
-
+\subsection{\code{intersect()}}{
 \Sexpr[stage=render,results=Rd]{generics:::methods_rd("intersect")}
+}
 
-\cr
-\strong{\code{union()}}
-
+\subsection{\code{union()}}{
 \Sexpr[stage=render,results=Rd]{generics:::methods_rd("union")}
+}
 
-\cr
-\strong{\code{setdiff()}}
-
+\subsection{\code{setdiff()}}{
 \Sexpr[stage=render,results=Rd]{generics:::methods_rd("setdiff")}
+}
 
-\cr
-\strong{\code{setequal()}}
-
+\subsection{\code{setequal()}}{
 \Sexpr[stage=render,results=Rd]{generics:::methods_rd("setequal")}
+}
 
-\cr
-\strong{\code{is.element()}}
-
+\subsection{\code{is.element()}}{
 \Sexpr[stage=render,results=Rd]{generics:::methods_rd("is.element")}
+}
 }
 
 \examples{

--- a/man/setops.Rd
+++ b/man/setops.Rd
@@ -44,7 +44,30 @@ default methods call the base versions.
 }
 \section{Methods}{
 
+
+\strong{\code{intersect()}}
+
 \Sexpr[stage=render,results=Rd]{generics:::methods_rd("intersect")}
+
+\cr
+\strong{\code{union()}}
+
+\Sexpr[stage=render,results=Rd]{generics:::methods_rd("union")}
+
+\cr
+\strong{\code{setdiff()}}
+
+\Sexpr[stage=render,results=Rd]{generics:::methods_rd("setdiff")}
+
+\cr
+\strong{\code{setequal()}}
+
+\Sexpr[stage=render,results=Rd]{generics:::methods_rd("setequal")}
+
+\cr
+\strong{\code{is.element()}}
+
+\Sexpr[stage=render,results=Rd]{generics:::methods_rd("is.element")}
 }
 
 \examples{


### PR DESCRIPTION
This adds dynamic documentation for the other generics in sets.R and coercion.R.

These print a bit different because right now these functions are grouped together (which I would agree is a good thing). Below is what they will look like. I've added a bold header for the generic name, and extra space between the final method of that generic and the next generic. I am open to other ideas. 

![screen shot 2018-10-09 at 9 48 37 am](https://user-images.githubusercontent.com/19150088/46673949-fc249400-cba8-11e8-8fb8-f358451129e6.png)
