### PR TITLE
Fix/pkgdown

### DIFF
--- a/R/augment.R
+++ b/R/augment.R
@@ -1,16 +1,16 @@
 #' Augment data with information from an object
-#' 
+#'
 #' @param x Model object or other R object with information to append to
 #'   observations.
-#' @param data A [data.frame()] or [tibble::tibble()] containing the original 
-#'  data that was used to produce the object `x`. 
+#' @param data A [data.frame()] or [tibble::tibble()] containing the original
+#'  data that was used to produce the object `x`.
 #' @param ... Addition arguments to `augment` method.
 #' @return A [tibble::tibble()] with information about data points.
 #' @section Methods:
-#' \Sexpr[stage=render,results=Rd]{generics:::methods_rd("augment")}
-#' 
+#' \Sexpr[stage=render,results=rd]{generics:::methods_rd("augment")}
+#'
 #' @export
-#' 
+#'
 augment <- function(x, data, ...) {
   UseMethod("augment")
 }

--- a/R/calculate.R
+++ b/R/calculate.R
@@ -1,9 +1,9 @@
-#' Calculate statistics. 
+#' Calculate statistics.
 #' @param x An object.
 #' @param ... Other arguments passed to methods
-#' 
+#'
 #' @section Methods:
-#' \Sexpr[stage=render,results=Rd]{generics:::methods_rd("calculate")}
+#' \Sexpr[stage=render,results=rd]{generics:::methods_rd("calculate")}
 #'
 #' @export
 calculate <- function(x, ...) {

--- a/R/coercion.R
+++ b/R/coercion.R
@@ -9,11 +9,11 @@
 #' @section Methods:
 #'
 #' \subsection{`as.factor()`}{
-#'    \Sexpr[stage=render,results=Rd]{generics:::methods_rd("as.factor")}
+#'    \Sexpr[stage=render,results=rd]{generics:::methods_rd("as.factor")}
 #' }
 #'
 #' \subsection{`as.ordered()`}{
-#'    \Sexpr[stage=render,results=Rd]{generics:::methods_rd("as.ordered")}
+#'    \Sexpr[stage=render,results=rd]{generics:::methods_rd("as.ordered")}
 #' }
 #'
 #'
@@ -56,7 +56,7 @@ as.ordered.default <- function(x, ...) base::as.ordered(x)
 #' types. The default method call the base version.
 #'
 #' @section Methods:
-#' \Sexpr[stage=render,results=Rd]{generics:::methods_rd("as.difftime")}
+#' \Sexpr[stage=render,results=rd]{generics:::methods_rd("as.difftime")}
 #'
 #' @param tim A vector specifying a time interval.
 #' @param format A single character specifying the format of `tim` when it is

--- a/R/compile.R
+++ b/R/compile.R
@@ -3,7 +3,7 @@
 #' Finalizes or completes an object.
 #'
 #' @section Methods:
-#' \Sexpr[stage=render,results=Rd]{generics:::methods_rd("compile")}
+#' \Sexpr[stage=render,results=rd]{generics:::methods_rd("compile")}
 #'
 #' @param object An object. See the individual method for specifics.
 #' @param ... Other arguments passed to methods

--- a/R/components.R
+++ b/R/components.R
@@ -13,7 +13,7 @@
 #' the object.
 #'
 #' @section Methods:
-#' \Sexpr[stage=render,results=Rd]{generics:::methods_rd("components")}
+#' \Sexpr[stage=render,results=rd]{generics:::methods_rd("components")}
 #'
 #' @export
 components <- function(object, ...) {

--- a/R/docs.R
+++ b/R/docs.R
@@ -111,7 +111,13 @@ help_path <- function(x, package) {
 
 locate_help_doc <- function(x, package) {
   help <- if (requireNamespace("pkgload", quietly = TRUE)) {
-    get("shim_help", asNamespace("pkgload"))
+    shim_help <- get("shim_help", asNamespace("pkgload"))
+    function(x, package = NULL) {
+      tryCatch(
+        expr = shim_help(x, (package)),
+        error = function(e) character()
+      )
+    }
   } else {
     utils::help
   }

--- a/R/equation.R
+++ b/R/equation.R
@@ -8,7 +8,7 @@
 #' @return Markup output suitable for rendering the equation.
 #'
 #' @section Methods:
-#' \Sexpr[stage=render,results=Rd]{generics:::methods_rd("equation")}
+#' \Sexpr[stage=render,results=rd]{generics:::methods_rd("equation")}
 #'
 #' @export
 equation <- function(object, ...) {

--- a/R/estfun.R
+++ b/R/estfun.R
@@ -1,7 +1,7 @@
 #' Extracting the estimating functions of a fitted model.
 #'
 #' @section Methods:
-#' \Sexpr[stage=render,results=Rd]{generics:::methods_rd("estfun")}
+#' \Sexpr[stage=render,results=rd]{generics:::methods_rd("estfun")}
 #'
 #' @param x A fitted model object.
 #' @param ... Other arguments passed to methods

--- a/R/evaluate.R
+++ b/R/evaluate.R
@@ -2,9 +2,9 @@
 #'
 #' @param x An object. See the individual method for specifics.
 #' @param ... other arguments passed to methods
-#' 
+#'
 #' @section Methods:
-#' \Sexpr[stage=render,results=Rd]{generics:::methods_rd("evaluate")}
+#' \Sexpr[stage=render,results=rd]{generics:::methods_rd("evaluate")}
 #'
 #' @inheritParams augment
 #' @export

--- a/R/explain.R
+++ b/R/explain.R
@@ -2,9 +2,9 @@
 #'
 #' @param x An object. See the individual method for specifics.
 #' @param ... other arguments passed to methods
-#' 
+#'
 #' @section Methods:
-#' \Sexpr[stage=render,results=Rd]{generics:::methods_rd("explain")}
+#' \Sexpr[stage=render,results=rd]{generics:::methods_rd("explain")}
 #'
 #' @inheritParams augment
 #' @export

--- a/R/fit.R
+++ b/R/fit.R
@@ -1,9 +1,9 @@
-#' Estimate model parameters. 
-#' 
-#' Estimates parameters for a given model from a set of data. 
-#' 
+#' Estimate model parameters.
+#'
+#' Estimates parameters for a given model from a set of data.
+#'
 #' @section Methods:
-#' \Sexpr[stage=render,results=Rd]{generics:::methods_rd("fit")}
+#' \Sexpr[stage=render,results=rd]{generics:::methods_rd("fit")}
 #'
 #' @inheritParams compile
 #' @export

--- a/R/fit_xy.R
+++ b/R/fit_xy.R
@@ -1,10 +1,10 @@
-#' Estimate model parameters. 
-#' 
+#' Estimate model parameters.
+#'
 #' Estimates parameters for a given model from a set of data in the form of
-#'  a set of predictors (`x`) and outcome(s) (`y`). 
-#' 
+#'  a set of predictors (`x`) and outcome(s) (`y`).
+#'
 #' @section Methods:
-#' \Sexpr[stage=render,results=Rd]{generics:::methods_rd("fit_xy")}
+#' \Sexpr[stage=render,results=rd]{generics:::methods_rd("fit_xy")}
 #'
 #' @inheritParams compile
 #' @export

--- a/R/generate.R
+++ b/R/generate.R
@@ -1,9 +1,9 @@
 #' Generate values based on inputs
 #' @param x An object.
 #' @param ... Other arguments passed to methods
-#' 
+#'
 #' @section Methods:
-#' \Sexpr[stage=render,results=Rd]{generics:::methods_rd("generate")}
+#' \Sexpr[stage=render,results=rd]{generics:::methods_rd("generate")}
 #'
 #' @export
 generate <- function(x, ...) {

--- a/R/glance.R
+++ b/R/glance.R
@@ -3,14 +3,14 @@
 #'#' Construct a single row summary "glance" of a model, fit, or other
 #' object
 #'
-#' glance methods always return either a one-row data frame (except on 
+#' glance methods always return either a one-row data frame (except on
 #'  `NULL`, which returns an empty data frame)
 #'
 #' @param x model or other R object to convert to single-row data frame
 #' @param ... other arguments passed to methods
-#' 
+#'
 #' @section Methods:
-#' \Sexpr[stage=render,results=Rd]{generics:::methods_rd("glance")}
+#' \Sexpr[stage=render,results=rd]{generics:::methods_rd("glance")}
 #'
 #' @export
 glance <- function(x, ...) {

--- a/R/hypothesize.R
+++ b/R/hypothesize.R
@@ -1,10 +1,10 @@
 #' Construct hypotheses.
-#' 
+#'
 #' @param x An object.
 #' @param ... Other arguments passed to methods
-#' 
+#'
 #' @section Methods:
-#' \Sexpr[stage=render,results=Rd]{generics:::methods_rd("hypothesize")}
+#' \Sexpr[stage=render,results=rd]{generics:::methods_rd("hypothesize")}
 #'
 #' @export
 hypothesize <- function(x, ...) {

--- a/R/interpolate.R
+++ b/R/interpolate.R
@@ -11,7 +11,7 @@
 #' with interpolated values.
 #'
 #' @section Methods:
-#' \Sexpr[stage=render,results=Rd]{generics:::methods_rd("interpolate")}
+#' \Sexpr[stage=render,results=rd]{generics:::methods_rd("interpolate")}
 #'
 #' @export
 interpolate <- function(object, ...) {

--- a/R/learn.R
+++ b/R/learn.R
@@ -1,12 +1,12 @@
-#' Estimate model parameters. 
-#' 
-#' Estimates parameters for a given model from a set of data. 
+#' Estimate model parameters.
+#'
+#' Estimates parameters for a given model from a set of data.
 #'
 #' @param x An object. See the individual method for specifics.
 #' @param ... other arguments passed to methods
-#' 
+#'
 #' @section Methods:
-#' \Sexpr[stage=render,results=Rd]{generics:::methods_rd("learn")}
+#' \Sexpr[stage=render,results=rd]{generics:::methods_rd("learn")}
 #'
 #' @inheritParams compile
 #' @export

--- a/R/prune.R
+++ b/R/prune.R
@@ -1,7 +1,7 @@
 #' Prune or reduce an object
 #'
 #' @section Methods:
-#' \Sexpr[stage=render,results=Rd]{generics:::methods_rd("prune")}
+#' \Sexpr[stage=render,results=rd]{generics:::methods_rd("prune")}
 #'
 #' @param tree A fitted model object.
 #' @param ... Other arguments passed to methods

--- a/R/refit.R
+++ b/R/refit.R
@@ -2,9 +2,9 @@
 #'
 #' @param object A fitted model object.
 #' @param ... Other arguments passed to methods
-#' 
+#'
 #' @section Methods:
-#' \Sexpr[stage=render,results=Rd]{generics:::methods_rd("refit")}
+#' \Sexpr[stage=render,results=rd]{generics:::methods_rd("refit")}
 #'
 #' @export
 refit <- function(object, ...) {

--- a/R/sets.R
+++ b/R/sets.R
@@ -11,23 +11,23 @@
 #' @section Methods:
 #'
 #' \subsection{`intersect()`}{
-#'     \Sexpr[stage=render,results=Rd]{generics:::methods_rd("intersect")}
+#'     \Sexpr[stage=render,results=rd]{generics:::methods_rd("intersect")}
 #' }
 #'
 #' \subsection{`union()`}{
-#'    \Sexpr[stage=render,results=Rd]{generics:::methods_rd("union")}
+#'    \Sexpr[stage=render,results=rd]{generics:::methods_rd("union")}
 #' }
 #'
 #' \subsection{`setdiff()`}{
-#'    \Sexpr[stage=render,results=Rd]{generics:::methods_rd("setdiff")}
+#'    \Sexpr[stage=render,results=rd]{generics:::methods_rd("setdiff")}
 #' }
 #'
 #' \subsection{`setequal()`}{
-#'    \Sexpr[stage=render,results=Rd]{generics:::methods_rd("setequal")}
+#'    \Sexpr[stage=render,results=rd]{generics:::methods_rd("setequal")}
 #' }
 #'
 #' \subsection{`is.element()`}{
-#'    \Sexpr[stage=render,results=Rd]{generics:::methods_rd("is.element")}
+#'    \Sexpr[stage=render,results=rd]{generics:::methods_rd("is.element")}
 #' }
 #'
 #' @param x,y Vectors to combine.

--- a/R/specify.R
+++ b/R/specify.R
@@ -1,10 +1,10 @@
 #' Specify variables or other quantities.
-#' 
+#'
 #' @param x An object.
 #' @param ... Other arguments passed to methods
-#' 
+#'
 #' @section Methods:
-#' \Sexpr[stage=render,results=Rd]{generics:::methods_rd("specify")}
+#' \Sexpr[stage=render,results=rd]{generics:::methods_rd("specify")}
 #'
 #' @export
 specify <- function(x, ...) {

--- a/R/tidy.R
+++ b/R/tidy.R
@@ -5,7 +5,7 @@
 #' @return A [tibble::tibble()] with information about model components.
 #'
 #' @section Methods:
-#' \Sexpr[stage=render,results=Rd]{generics:::methods_rd("tidy")}
+#' \Sexpr[stage=render,results=rd]{generics:::methods_rd("tidy")}
 #'
 #' @export
 tidy <- function(x, ...) {

--- a/R/train.R
+++ b/R/train.R
@@ -1,12 +1,12 @@
-#' Estimate model parameters. 
-#' 
-#' Estimates parameters for a given model from a set of data. 
+#' Estimate model parameters.
+#'
+#' Estimates parameters for a given model from a set of data.
 #'
 #' @param x An object. See the individual method for specifics.
 #' @param ... other arguments passed to methods
-#' 
+#'
 #' @section Methods:
-#' \Sexpr[stage=render,results=Rd]{generics:::methods_rd("train")}
+#' \Sexpr[stage=render,results=rd]{generics:::methods_rd("train")}
 #'
 #' @export
 train <- function(x, ...) {

--- a/R/var_imp.R
+++ b/R/var_imp.R
@@ -1,12 +1,12 @@
 #' Calculation of variable importance
 #'
 #' A generic method for calculating variable importance for model objects.
-#' 
+#'
 #' @param object A fitted model object.
 #' @param ... Other arguments passed to methods
-#' 
+#'
 #' @section Methods:
-#' \Sexpr[stage=render,results=Rd]{generics:::methods_rd("var_imp")}
+#' \Sexpr[stage=render,results=rd]{generics:::methods_rd("var_imp")}
 #'
 #' @inheritParams compile
 #' @export

--- a/R/varying_args.R
+++ b/R/varying_args.R
@@ -1,7 +1,7 @@
-#' Find any arguments that are not fully specified. 
+#' Find any arguments that are not fully specified.
 #'
 #' @section Methods:
-#' \Sexpr[stage=render,results=Rd]{generics:::methods_rd("varying_args")}
+#' \Sexpr[stage=render,results=rd]{generics:::methods_rd("varying_args")}
 #'
 #' @inheritParams compile
 #' @export

--- a/R/visualize.R
+++ b/R/visualize.R
@@ -1,10 +1,10 @@
-#' Visualize a data set or object. 
-#' 
-#' @param x A data frame or other object. 
+#' Visualize a data set or object.
+#'
+#' @param x A data frame or other object.
 #' @param ... Other arguments passed to methods
-#' 
+#'
 #' @section Methods:
-#' \Sexpr[stage=render,results=Rd]{generics:::methods_rd("visualize")}
+#' \Sexpr[stage=render,results=rd]{generics:::methods_rd("visualize")}
 #'
 #' @export
 visualize <- function(x, ...) {

--- a/man/augment.Rd
+++ b/man/augment.Rd
@@ -23,6 +23,6 @@ Augment data with information from an object
 }
 \section{Methods}{
 
-\Sexpr[stage=render,results=Rd]{generics:::methods_rd("augment")}
+\Sexpr[stage=render,results=rd]{generics:::methods_rd("augment")}
 }
 

--- a/man/calculate.Rd
+++ b/man/calculate.Rd
@@ -16,6 +16,6 @@ Calculate statistics.
 }
 \section{Methods}{
 
-\Sexpr[stage=render,results=Rd]{generics:::methods_rd("calculate")}
+\Sexpr[stage=render,results=rd]{generics:::methods_rd("calculate")}
 }
 

--- a/man/coercion-factor.Rd
+++ b/man/coercion-factor.Rd
@@ -31,11 +31,11 @@ default methods call the base versions.
 
 
 \subsection{\code{as.factor()}}{
-\Sexpr[stage=render,results=Rd]{generics:::methods_rd("as.factor")}
+\Sexpr[stage=render,results=rd]{generics:::methods_rd("as.factor")}
 }
 
 \subsection{\code{as.ordered()}}{
-\Sexpr[stage=render,results=Rd]{generics:::methods_rd("as.ordered")}
+\Sexpr[stage=render,results=rd]{generics:::methods_rd("as.ordered")}
 }
 }
 

--- a/man/coercion-time-difference.Rd
+++ b/man/coercion-time-difference.Rd
@@ -35,7 +35,7 @@ types. The default method call the base version.
 }
 \section{Methods}{
 
-\Sexpr[stage=render,results=Rd]{generics:::methods_rd("as.difftime")}
+\Sexpr[stage=render,results=rd]{generics:::methods_rd("as.difftime")}
 }
 
 \examples{

--- a/man/compile.Rd
+++ b/man/compile.Rd
@@ -16,6 +16,6 @@ Finalizes or completes an object.
 }
 \section{Methods}{
 
-\Sexpr[stage=render,results=Rd]{generics:::methods_rd("compile")}
+\Sexpr[stage=render,results=rd]{generics:::methods_rd("compile")}
 }
 

--- a/man/components.Rd
+++ b/man/components.Rd
@@ -25,6 +25,6 @@ to extract these components in a tidy data format.
 }
 \section{Methods}{
 
-\Sexpr[stage=render,results=Rd]{generics:::methods_rd("components")}
+\Sexpr[stage=render,results=rd]{generics:::methods_rd("components")}
 }
 

--- a/man/equation.Rd
+++ b/man/equation.Rd
@@ -19,6 +19,6 @@ Display the mathematical representation of a fitted model.
 }
 \section{Methods}{
 
-\Sexpr[stage=render,results=Rd]{generics:::methods_rd("equation")}
+\Sexpr[stage=render,results=rd]{generics:::methods_rd("equation")}
 }
 

--- a/man/estfun.Rd
+++ b/man/estfun.Rd
@@ -16,6 +16,6 @@ Extracting the estimating functions of a fitted model.
 }
 \section{Methods}{
 
-\Sexpr[stage=render,results=Rd]{generics:::methods_rd("estfun")}
+\Sexpr[stage=render,results=rd]{generics:::methods_rd("estfun")}
 }
 

--- a/man/evaluate.Rd
+++ b/man/evaluate.Rd
@@ -16,6 +16,6 @@ Evaluate an object.
 }
 \section{Methods}{
 
-\Sexpr[stage=render,results=Rd]{generics:::methods_rd("evaluate")}
+\Sexpr[stage=render,results=rd]{generics:::methods_rd("evaluate")}
 }
 

--- a/man/explain.Rd
+++ b/man/explain.Rd
@@ -16,6 +16,6 @@ Explain details of an object
 }
 \section{Methods}{
 
-\Sexpr[stage=render,results=Rd]{generics:::methods_rd("explain")}
+\Sexpr[stage=render,results=rd]{generics:::methods_rd("explain")}
 }
 

--- a/man/fit.Rd
+++ b/man/fit.Rd
@@ -16,6 +16,6 @@ Estimates parameters for a given model from a set of data.
 }
 \section{Methods}{
 
-\Sexpr[stage=render,results=Rd]{generics:::methods_rd("fit")}
+\Sexpr[stage=render,results=rd]{generics:::methods_rd("fit")}
 }
 

--- a/man/fit_xy.Rd
+++ b/man/fit_xy.Rd
@@ -17,6 +17,6 @@ a set of predictors (\code{x}) and outcome(s) (\code{y}).
 }
 \section{Methods}{
 
-\Sexpr[stage=render,results=Rd]{generics:::methods_rd("fit_xy")}
+\Sexpr[stage=render,results=rd]{generics:::methods_rd("fit_xy")}
 }
 

--- a/man/generate.Rd
+++ b/man/generate.Rd
@@ -16,6 +16,6 @@ Generate values based on inputs
 }
 \section{Methods}{
 
-\Sexpr[stage=render,results=Rd]{generics:::methods_rd("generate")}
+\Sexpr[stage=render,results=rd]{generics:::methods_rd("generate")}
 }
 

--- a/man/glance.Rd
+++ b/man/glance.Rd
@@ -21,6 +21,6 @@ glance methods always return either a one-row data frame (except on
 }
 \section{Methods}{
 
-\Sexpr[stage=render,results=Rd]{generics:::methods_rd("glance")}
+\Sexpr[stage=render,results=rd]{generics:::methods_rd("glance")}
 }
 

--- a/man/hypothesize.Rd
+++ b/man/hypothesize.Rd
@@ -16,6 +16,6 @@ Construct hypotheses.
 }
 \section{Methods}{
 
-\Sexpr[stage=render,results=Rd]{generics:::methods_rd("hypothesize")}
+\Sexpr[stage=render,results=rd]{generics:::methods_rd("hypothesize")}
 }
 

--- a/man/interpolate.Rd
+++ b/man/interpolate.Rd
@@ -22,6 +22,6 @@ fitted model.
 }
 \section{Methods}{
 
-\Sexpr[stage=render,results=Rd]{generics:::methods_rd("interpolate")}
+\Sexpr[stage=render,results=rd]{generics:::methods_rd("interpolate")}
 }
 

--- a/man/learn.Rd
+++ b/man/learn.Rd
@@ -16,6 +16,6 @@ Estimates parameters for a given model from a set of data.
 }
 \section{Methods}{
 
-\Sexpr[stage=render,results=Rd]{generics:::methods_rd("learn")}
+\Sexpr[stage=render,results=rd]{generics:::methods_rd("learn")}
 }
 

--- a/man/prune.Rd
+++ b/man/prune.Rd
@@ -16,6 +16,6 @@ Prune or reduce an object
 }
 \section{Methods}{
 
-\Sexpr[stage=render,results=Rd]{generics:::methods_rd("prune")}
+\Sexpr[stage=render,results=rd]{generics:::methods_rd("prune")}
 }
 

--- a/man/refit.Rd
+++ b/man/refit.Rd
@@ -16,6 +16,6 @@ Refitting models
 }
 \section{Methods}{
 
-\Sexpr[stage=render,results=Rd]{generics:::methods_rd("refit")}
+\Sexpr[stage=render,results=rd]{generics:::methods_rd("refit")}
 }
 

--- a/man/setops.Rd
+++ b/man/setops.Rd
@@ -46,23 +46,23 @@ default methods call the base versions.
 
 
 \subsection{\code{intersect()}}{
-\Sexpr[stage=render,results=Rd]{generics:::methods_rd("intersect")}
+\Sexpr[stage=render,results=rd]{generics:::methods_rd("intersect")}
 }
 
 \subsection{\code{union()}}{
-\Sexpr[stage=render,results=Rd]{generics:::methods_rd("union")}
+\Sexpr[stage=render,results=rd]{generics:::methods_rd("union")}
 }
 
 \subsection{\code{setdiff()}}{
-\Sexpr[stage=render,results=Rd]{generics:::methods_rd("setdiff")}
+\Sexpr[stage=render,results=rd]{generics:::methods_rd("setdiff")}
 }
 
 \subsection{\code{setequal()}}{
-\Sexpr[stage=render,results=Rd]{generics:::methods_rd("setequal")}
+\Sexpr[stage=render,results=rd]{generics:::methods_rd("setequal")}
 }
 
 \subsection{\code{is.element()}}{
-\Sexpr[stage=render,results=Rd]{generics:::methods_rd("is.element")}
+\Sexpr[stage=render,results=rd]{generics:::methods_rd("is.element")}
 }
 }
 

--- a/man/specify.Rd
+++ b/man/specify.Rd
@@ -16,6 +16,6 @@ Specify variables or other quantities.
 }
 \section{Methods}{
 
-\Sexpr[stage=render,results=Rd]{generics:::methods_rd("specify")}
+\Sexpr[stage=render,results=rd]{generics:::methods_rd("specify")}
 }
 

--- a/man/tidy.Rd
+++ b/man/tidy.Rd
@@ -19,6 +19,6 @@ Turn an object into a tidy tibble
 }
 \section{Methods}{
 
-\Sexpr[stage=render,results=Rd]{generics:::methods_rd("tidy")}
+\Sexpr[stage=render,results=rd]{generics:::methods_rd("tidy")}
 }
 

--- a/man/train.Rd
+++ b/man/train.Rd
@@ -16,6 +16,6 @@ Estimates parameters for a given model from a set of data.
 }
 \section{Methods}{
 
-\Sexpr[stage=render,results=Rd]{generics:::methods_rd("train")}
+\Sexpr[stage=render,results=rd]{generics:::methods_rd("train")}
 }
 

--- a/man/var_imp.Rd
+++ b/man/var_imp.Rd
@@ -16,6 +16,6 @@ A generic method for calculating variable importance for model objects.
 }
 \section{Methods}{
 
-\Sexpr[stage=render,results=Rd]{generics:::methods_rd("var_imp")}
+\Sexpr[stage=render,results=rd]{generics:::methods_rd("var_imp")}
 }
 

--- a/man/varying_args.Rd
+++ b/man/varying_args.Rd
@@ -16,6 +16,6 @@ Find any arguments that are not fully specified.
 }
 \section{Methods}{
 
-\Sexpr[stage=render,results=Rd]{generics:::methods_rd("varying_args")}
+\Sexpr[stage=render,results=rd]{generics:::methods_rd("varying_args")}
 }
 

--- a/man/visualize.Rd
+++ b/man/visualize.Rd
@@ -16,6 +16,6 @@ Visualize a data set or object.
 }
 \section{Methods}{
 
-\Sexpr[stage=render,results=Rd]{generics:::methods_rd("visualize")}
+\Sexpr[stage=render,results=rd]{generics:::methods_rd("visualize")}
 }
 


### PR DESCRIPTION
Two fixes for `pkgdown` to work.

1) For the `\Sexpr` blocks, we now say `rd` rather than `Rd`. `pkgdown` failed with `Rd`. This is the right way to specify the `results` section even though `Rd` works since whatever parses it does not seem to be case sensitive (maybe `pkgdown` should be more forgiving here and not be case sensitive either?).

2) When viewing development help interactively, `pkgload:::shim_help()` is being used. When this hits a method it cannot find documentation for, it errors. `utils::help()` returns a custom character object along with a message. We now use a `tryCatch()` when `shim_help()` is used, and return `character()` if no help is found. This was specifically added for the case of default methods that we export but dont document like:

``` r
library(generics)
library(pkgload)

# not an error!
help("as.factor.default", "generics")
#> No documentation for 'as.factor.default' in specified packages and libraries:
#> you could try '??as.factor.default'

str(help("as.factor.default", "generics"))
#>  'help_files_with_topic' chr(0) 
#>  - attr(*, "call")= language help(topic = "as.factor.default", package = "generics")
#>  - attr(*, "topic")= chr "as.factor.default"
#>  - attr(*, "tried_all_packages")= logi FALSE
#>  - attr(*, "type")= chr "text"

# (inside generics R Project)
# load dev generics, sorry about hard path
pkgload::load_all("~/Desktop/r/packages/generics")
#> Loading generics

# now using dev help
help("as.factor.default", "generics")
#> Error: Could not find development topic 'as.factor.default'

# and that called:
pkgload:::shim_help("as.factor.default", "generics")
#> Error: Could not find development topic 'as.factor.default'
```

I don't think this is an error on `pkgload`'s part. It's fine to throw an error. But for `generics`, we pass every method that `attr(utils::methods("as.factor"), "info")` can find through `help()` to find the path to any help docs. This is also our way of actually determining if help docs even exist. So we don't want it to error if they don't exist, we just want to handle appropriately and not include in the dynamic Rd.