### PR TITLE
Fixed README example for providing S3 methods

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -41,9 +41,9 @@ fit
 tidy
 ```
 
-To use `generics` with your package, we recommend that you import and re-export the generic(s) of interest. For example, if you want to provide a method for the  S3 `fit()` method, you'd using the following `roxygen2` code:
+To use `generics` with your package, we recommend that you import and re-export the generic(s) of interest. For example, if you want to provide a method for the  S3 `explain()` method, you'd using the following `roxygen2` code:
 
-``` {r}
+``` {r, eval = FALSE}
 #' @importFrom generics explain
 #' @export
 generics::explain

--- a/README.md
+++ b/README.md
@@ -62,19 +62,13 @@ tidy
 
 To use `generics` with your package, we recommend that you import and
 re-export the generic(s) of interest. For example, if you want to
-provide a method for the S3 `fit()` method, you’d using the following
-`roxygen2` code:
+provide a method for the S3 `explain()` method, you’d using the
+following `roxygen2` code:
 
 ``` r
 #' @importFrom generics explain
 #' @export
 generics::explain
-#> function (x, ...) 
-#> {
-#>     UseMethod("explain")
-#> }
-#> <bytecode: 0x7faffdb7e0c8>
-#> <environment: namespace:generics>
 ```
 
 As an example, the [recipes](https://github.com/tidymodels/recipes)


### PR DESCRIPTION
The explanation in the README discusses adding a `fit()` method, but the code shows an example of adding an `explain()` method.

This PR fixes this incosistency, and prevents evaluation of the chunk (as package authors are not required to include the print output of the generic).