### PR TITLE
Remove data argument from augment() signature

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ License: GPL-2
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 6.1.0.9000
+RoxygenNote: 6.1.1
 URL: https://github.com/r-lib/generics
 BugReports: https://github.com/r-lib/generics
 Depends: 

--- a/R/augment.R
+++ b/R/augment.R
@@ -2,8 +2,6 @@
 #'
 #' @param x Model object or other R object with information to append to
 #'   observations.
-#' @param data A [data.frame()] or [tibble::tibble()] containing the original
-#'  data that was used to produce the object `x`.
 #' @param ... Addition arguments to `augment` method.
 #' @return A [tibble::tibble()] with information about data points.
 #' @section Methods:
@@ -11,6 +9,6 @@
 #'
 #' @export
 #'
-augment <- function(x, data, ...) {
+augment <- function(x, ...) {
   UseMethod("augment")
 }

--- a/man/augment.Rd
+++ b/man/augment.Rd
@@ -4,14 +4,11 @@
 \alias{augment}
 \title{Augment data with information from an object}
 \usage{
-augment(x, data, ...)
+augment(x, ...)
 }
 \arguments{
 \item{x}{Model object or other R object with information to append to
 observations.}
-
-\item{data}{A \code{\link[=data.frame]{data.frame()}} or \code{\link[tibble:tibble]{tibble::tibble()}} containing the original
-data that was used to produce the object \code{x}.}
 
 \item{...}{Addition arguments to \code{augment} method.}
 }


### PR DESCRIPTION
Results in warnings for `broom::augment.stl()` and `broom::augment.rowwise_df()`, which don't have a data argument. Both of these functions are likely to be deprecated at some point so that we can add the `data` argument back, but this currently results in a WARNING that may or may not bother the CRAN people as I work on some quick patches for the `broom 0.5.1` release.

Not sure if this would even make it to CRAN in time to matter, but I could at least tell them it's in the pipeline. Advice on whether or not this change really matters appreciated.